### PR TITLE
[Fix] Message에서 isOwner 따라 관점 달라지도록 메시지 조회 다르게 개발

### DIFF
--- a/artichat/src/main/java/com/talkhasam/artichat/domain/chatroom/service/ChatRoomService.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/domain/chatroom/service/ChatRoomService.java
@@ -50,7 +50,7 @@ public class ChatRoomService {
                 .modifiedAt(Instant.now())
                 .build();
         chatRoomRepository.save(chatRoom);
-        ChatUserLoginDataDto chatUserLoginDataDto = chatUserService.createUser(chatRoomId, dto.owner(), dto.password());
+        ChatUserLoginDataDto chatUserLoginDataDto = chatUserService.createUser(chatRoomId, dto.owner(), dto.password(), true);
         return new ChatRoomPostResponseDto(chatRoomId, chatUserLoginDataDto);
     }
 

--- a/artichat/src/main/java/com/talkhasam/artichat/domain/chatuser/service/ChatUserService.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/domain/chatuser/service/ChatUserService.java
@@ -36,20 +36,20 @@ public class ChatUserService {
         chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         // 로그인 또는 신규 회원가입 처리
-        return createUser(chatRoomId, requestDto.nickname(), requestDto.password());
+        return createUser(chatRoomId, requestDto.nickname(), requestDto.password(), false);
     }
 
     // 로그인 또는 회원가입 후 JWT 토큰 반환
-    public ChatUserLoginDataDto createUser(long chatRoomId, String nickname, String password) {
+    public ChatUserLoginDataDto createUser(long chatRoomId, String nickname, String password, boolean isOwner) {
         // 로그인 또는 신규 회원가입 처리
-        ChatUser chatUser = saveOrGet(chatRoomId, nickname, password);
+        ChatUser chatUser = saveOrGet(chatRoomId, nickname, password, isOwner);
         // 토큰 생성
-        String accessToken = tokenService.generateToken(String.valueOf(chatUser.getId()));
+        String accessToken = tokenService.generateToken(String.valueOf(chatUser.getId()), isOwner);
         return new ChatUserLoginDataDto(accessToken, chatUser.isOwner());
     }
 
     // 기존 유저 조회 후 비밀번호 인증, 없으면 신규 생성
-    private ChatUser saveOrGet(long chatRoomId, String nickname, String rawPassword) {
+    private ChatUser saveOrGet(long chatRoomId, String nickname, String rawPassword, boolean isOwner) {
         // 채팅방 id와 닉네임으로 조회
         Optional<ChatUser> existingUser = chatUserRepository.findByChatRoomIdAndNickname(chatRoomId, nickname);
 
@@ -64,9 +64,6 @@ public class ChatUserService {
                 throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
             }
         }
-
-        // 신규 가입인 경우 방장
-        boolean isOwner = chatUserRepository.countByChatRoomId(chatRoomId) == 0;
 
         String encodedPassword = encoder.encode(rawPassword);
         ChatUser newChatUser = ChatUser.builder()

--- a/artichat/src/main/java/com/talkhasam/artichat/domain/message/controller/MessageController.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/domain/message/controller/MessageController.java
@@ -27,7 +27,6 @@ public class MessageController {
             @RequestParam(defaultValue = "20") @Positive int limit,
             @RequestParam(required = false) Long startId
     ) {
-        var response = messageService.getMessageList(chatRoomId, limit, startId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok( messageService.getMessageListByIsOwnerStatus(chatRoomId, limit, startId));
     }
 }

--- a/artichat/src/main/java/com/talkhasam/artichat/domain/message/repository/MessageDynamoRepository.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/domain/message/repository/MessageDynamoRepository.java
@@ -1,11 +1,13 @@
 package com.talkhasam.artichat.domain.message.repository;
 
 import com.talkhasam.artichat.domain.message.entity.Message;
-import io.micrometer.common.lang.Nullable;
-import lombok.Getter;
+import com.talkhasam.artichat.global.common.PageResult;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Expression;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.PageIterable;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
@@ -13,7 +15,6 @@ import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Repository
@@ -21,59 +22,89 @@ import java.util.Map;
 public class MessageDynamoRepository implements MessageRepository {
     private final DynamoDbTable<Message> table;
 
-    // 페이지 결과 DTO
-    @Getter
-    public static class PageResult<T> {
-        private final List<T> items;
-        private final Long nextKey;
-
-        public PageResult(List<T> items, Long nextKey) {
-            this.items = items;
-            this.nextKey = nextKey;
-        }
-    }
-
+    // 메시지 저장
     @Override
     public void save(Message msg) {
         table.putItem(msg);
     }
 
-    // 방별 메시지 조회 (최신순 페이징)
+    // chatRoomId로 메시지 조회 (최신순, 페이징)
     @Override
-    public PageResult<Message> findByChatRoomId(
-            long chatRoomId,
-            int limit,
-            @Nullable Long startId
-    ) {
-        // 1) Query 조건 설정
+    public PageResult<Message> findByChatRoomId(long chatRoomId, int limit, @Nullable Long exclusiveStartMessageId) {
         QueryEnhancedRequest.Builder req = QueryEnhancedRequest.builder()
-                .queryConditional(QueryConditional.keyEqualTo(k ->
-                        k.partitionValue(chatRoomId)
-                ))
-                .scanIndexForward(false) // 최신순 정렬
+                .queryConditional(QueryConditional.keyEqualTo(k -> k.partitionValue(chatRoomId)))
+                .scanIndexForward(false)
                 .limit(limit);
 
-        // 2) startMessageId가 있으면 exclusiveStartKey 구성
-        if (startId != null) {
-            Map<String, AttributeValue> exclusiveStartKey = new HashMap<>();
-            exclusiveStartKey.put("chatRoomId", AttributeValue.builder().n(String.valueOf(chatRoomId)).build());
-            exclusiveStartKey.put("id", AttributeValue.builder().n(String.valueOf(startId)).build());
-            req.exclusiveStartKey(exclusiveStartKey);
+        return queryWithPaging(chatRoomId, exclusiveStartMessageId, req);
+    }
+
+    // chatRoomId로 isOwner=true인 메시지 조회 (최신순, 페이징)
+    @Override
+    public PageResult<Message> findByChatRoomIdAndIsOwnerTrue(long chatRoomId, int limit, Long exclusiveStartMessageId) {
+        QueryEnhancedRequest.Builder req = QueryEnhancedRequest.builder()
+                .queryConditional(QueryConditional.keyEqualTo(k -> k.partitionValue(chatRoomId)))
+                .filterExpression(Expression.builder()
+                        .expression("isOwner = :trueVal")
+                        .putExpressionValue(":trueVal", AttributeValue.builder().bool(true).build())
+                        .build())
+                .scanIndexForward(false)
+                .limit(limit);
+
+        return queryWithPaging(chatRoomId, exclusiveStartMessageId, req);
+    }
+
+    // chatUserId 인덱스로 메시지 조회 (최신순, 페이징)
+    @Override
+    public PageResult<Message> findByChatUserId(long chatUserId, int limit, Long exclusiveStartMessageId) {
+        QueryEnhancedRequest.Builder req = QueryEnhancedRequest.builder()
+                .queryConditional(QueryConditional.keyEqualTo(k -> k.partitionValue(chatUserId)))
+                .scanIndexForward(false)
+                .limit(limit);
+
+        // 페이징용 시작키 설정
+        if (exclusiveStartMessageId != null) {
+            req.exclusiveStartKey(buildExclusiveStartKey("chatUserId", chatUserId, exclusiveStartMessageId));
         }
 
-        // 3) DynamoDB 쿼리 수행
+        // chatUserId GSI 사용 쿼리
+        SdkIterable<Page<Message>> pages = table.index("chatUserId-index").query(req.build());
+        Page<Message> page = pages.stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("페이지를 찾을 수 없습니다."));
+
+        return buildPageResult(page);
+    }
+
+    // 공통: DynamoDB 쿼리 및 페이징 처리
+    private PageResult<Message> queryWithPaging(long partitionValue, Long exclusiveStartMessageId, QueryEnhancedRequest.Builder req) {
+        if (exclusiveStartMessageId != null) {
+            req.exclusiveStartKey(buildExclusiveStartKey("chatRoomId", partitionValue, exclusiveStartMessageId));
+        }
+
         PageIterable<Message> pages = table.query(req.build());
         Page<Message> page = pages.stream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("페이지를 찾을 수 없습니다."));
 
-        // 4) 다음 페이지 키 추출
+        return buildPageResult(page);
+    }
+
+    // exclusiveStartKey를 생성 (파티션키명, 파티션값, 정렬키값)
+    private Map<String, AttributeValue> buildExclusiveStartKey(String partitionKeyName, long partitionValue, Long sortKeyValue) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put(partitionKeyName, AttributeValue.builder().n(String.valueOf(partitionValue)).build());
+        key.put("id", AttributeValue.builder().n(String.valueOf(sortKeyValue)).build());
+        return key;
+    }
+
+    // 페이지 결과를 PageResult 객체로 변환 (아이템과 다음 키 포함)
+    private PageResult<Message> buildPageResult(Page<Message> page) {
         Map<String, AttributeValue> lastKey = page.lastEvaluatedKey();
         Long nextKey = null;
         if (lastKey != null && lastKey.containsKey("id")) {
             nextKey = Long.valueOf(lastKey.get("id").n());
         }
-
         return new PageResult<>(page.items(), nextKey);
     }
 }

--- a/artichat/src/main/java/com/talkhasam/artichat/domain/message/repository/MessageRepository.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/domain/message/repository/MessageRepository.java
@@ -1,8 +1,11 @@
 package com.talkhasam.artichat.domain.message.repository;
 
 import com.talkhasam.artichat.domain.message.entity.Message;
+import com.talkhasam.artichat.global.common.PageResult;
 
 public interface MessageRepository {
     void save(Message message);
-    MessageDynamoRepository.PageResult<Message> findByChatRoomId(long chatRoomId, int limit, Long exclusiveStartMessageId);
+    PageResult<Message> findByChatRoomId(long chatRoomId, int limit, Long exclusiveStartMessageId);
+    PageResult<Message> findByChatRoomIdAndIsOwnerTrue(long chatRoomId, int limit, Long exclusiveStartMessageId);
+    PageResult<Message> findByChatUserId(long chatUserId, int limit, Long exclusiveStartMessageId);
 }

--- a/artichat/src/main/java/com/talkhasam/artichat/domain/message/service/MessageService.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/domain/message/service/MessageService.java
@@ -2,15 +2,25 @@ package com.talkhasam.artichat.domain.message.service;
 
 import com.talkhasam.artichat.domain.message.dto.MessageDto;
 import com.talkhasam.artichat.domain.message.dto.MessageListResponseDto;
+import com.talkhasam.artichat.domain.message.entity.Message;
 import com.talkhasam.artichat.domain.message.repository.MessageRepository;
+import com.talkhasam.artichat.global.common.PageResult;
+import com.talkhasam.artichat.global.exception.CustomException;
+import com.talkhasam.artichat.global.exception.ErrorCode;
+import com.talkhasam.artichat.global.security.CustomTokenService;
 import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
@@ -18,9 +28,10 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class MessageService {
     private final MessageRepository messageRepository;
+    private final CustomTokenService customTokenService;
 
-    public MessageListResponseDto getMessageList(long chatRoomId, int limit, @Nullable Long startId) {
-        var page = messageRepository.findByChatRoomId(chatRoomId, limit, startId);
+    public MessageListResponseDto getMessageListAll(long chatRoomId, int limit, @Nullable Long startId) {
+        PageResult<Message> page = messageRepository.findByChatRoomId(chatRoomId, limit, startId);
         List<MessageDto> messages = page.getItems().stream()
                 .map(MessageDto::from)
                 .collect(Collectors.toList());
@@ -28,4 +39,50 @@ public class MessageService {
         return new MessageListResponseDto(messages, nextKey);
     }
 
+    public MessageListResponseDto getMessageListByIsOwnerStatus(
+            long chatRoomId, int limit, @Nullable Long startId
+    ) {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                .getRequest();
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+        String token = bearerToken.substring(7);
+        Long loginUserId = Long.parseLong(customTokenService.extractUsername(token));
+        boolean loginUserisOwner = customTokenService.extractIsOwner(token);
+        List<Message> messages;
+        Long nextKey;
+
+        if (loginUserisOwner) { // isOwner=true라면 전체 메시지 조회
+            PageResult<Message> page = messageRepository.findByChatRoomId(chatRoomId, limit, startId);
+            messages = page.getItems();
+            nextKey = page.getNextKey();
+        } else {
+            // isOwner=true인 메시지와, isOwner=false & chatUserId = loginUserId 메시지 조회 (페이징 처리 필요)
+            PageResult<Message> pageTrueOwner = messageRepository.findByChatRoomIdAndIsOwnerTrue(chatRoomId, limit, startId);
+            PageResult<Message> pageFalseOwnerMine = messageRepository.findByChatUserId(loginUserId, limit, startId);
+
+            // 메시지 병합 및 정렬 (최신순)
+            List<Message> merged = Stream.concat(pageTrueOwner.getItems().stream(), pageFalseOwnerMine.getItems().stream())
+                    .sorted(Comparator.comparing(Message::getCreatedAt).reversed())
+                    .collect(Collectors.toList());
+
+            // 병합 후 nextKey 계산
+            messages = merged.size() > limit ? merged.subList(0, limit) : merged;
+            nextKey = calculateNextKey(messages);
+        }
+        List<MessageDto> messageDtos = messages.stream()
+                .map(MessageDto::from)
+                .collect(Collectors.toList());
+        return new MessageListResponseDto(messageDtos, nextKey);
+    }
+
+    private Long calculateNextKey(List<Message> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return null; // 다음 페이지 없음
+        }
+        // 마지막 메시지의 ID 반환
+        return messages.getLast().getId();
+    }
 }

--- a/artichat/src/main/java/com/talkhasam/artichat/global/common/PageResult.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/common/PageResult.java
@@ -1,0 +1,16 @@
+package com.talkhasam.artichat.global.common;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PageResult<T> {
+    private final List<T> items;
+    private final Long nextKey;
+
+    public PageResult(List<T> items, Long nextKey) {
+        this.items = items;
+        this.nextKey = nextKey;
+    }
+}

--- a/artichat/src/main/java/com/talkhasam/artichat/global/config/SecurityConfig.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/config/SecurityConfig.java
@@ -78,10 +78,10 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs", "/v3/api-docs/**", "/webjars/**").permitAll()
                         .requestMatchers("/chatusers/login").permitAll()
                         .requestMatchers("/ws-chat/**").permitAll()
+                        .requestMatchers("/chatrooms/{chatRoomId}/messages").authenticated()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(tokenFilter, UsernamePasswordAuthenticationFilter.class);
-
         return http.build();
     }
 }

--- a/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomAuthenticationProvider.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomAuthenticationProvider.java
@@ -3,7 +3,6 @@ package com.talkhasam.artichat.global.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,8 +13,8 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) {
         CustomAuthenticationToken token = (CustomAuthenticationToken) authentication;
-        UserDetails user = userDetailsService.loadUserByUsername(token.getUsername());
-        return new CustomAuthenticationToken(user,null, user.getAuthorities());
+        CustomUserDetails user = userDetailsService.loadUserById(Long.parseLong(token.getUsername()));
+        return new CustomAuthenticationToken(user,null, user.getAuthorities(), user.isOwner());
     }
 
     @Override

--- a/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomAuthenticationToken.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomAuthenticationToken.java
@@ -12,21 +12,26 @@ public class CustomAuthenticationToken extends AbstractAuthenticationToken {
     @Getter
     private final String username;
     private final Object credentials;  // password or null
+    @Getter
+    private final boolean isOwner;
 
     public CustomAuthenticationToken(String username, Object credentials) {
         super(null);
         this.username = username;
         this.credentials = credentials;
+        this.isOwner = false; // 기본값
         setAuthenticated(false);
     }
 
     // 인증 완료 후 사용될 생성자
     public CustomAuthenticationToken(UserDetails principal,
                                      Object credentials,
-                                     Collection<? extends GrantedAuthority> authorities) {
+                                     Collection<? extends GrantedAuthority> authorities,
+                                     boolean isOwner) {
         super(authorities);
         this.username = null;
         this.credentials = credentials;
+        this.isOwner = isOwner;
         setAuthenticated(true);
         super.setDetails(principal);
     }

--- a/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomTokenService.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomTokenService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 
 @Slf4j
@@ -33,9 +35,13 @@ public class CustomTokenService {
         this.accessKey = Keys.hmacShaKeyFor(accessSecret.getBytes());
     }
 
-    public String generateToken(String userId) {
+    public String generateToken(String userId, boolean isOwner) {
         Date now = new Date();
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("isOwner", isOwner);   // isOwner 클레임 추가
+
         return Jwts.builder()
+                .setClaims(claims)
                 .setSubject(userId)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + expirationMs))
@@ -64,7 +70,26 @@ public class CustomTokenService {
                     .getBody();
             return claims.getSubject();
         } catch (JwtException | IllegalArgumentException e) {
-            log.error("JWT parsing failed: " + e.getMessage(), e);
+            log.error("JWT parsing failed: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public boolean extractIsOwner(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(accessKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            Object isOwner = claims.get("isOwner");
+            return switch (isOwner) {
+                case Boolean b -> b;
+                case String s -> Boolean.parseBoolean(s);
+                case null, default -> false;
+            };
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("JWT parsing failed: {}", e.getMessage(), e);
             throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
     }

--- a/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomUserDetails.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package com.talkhasam.artichat.global.security;
+
+import com.talkhasam.artichat.domain.chatuser.entity.ChatUser;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private final ChatUser user;
+
+    public CustomUserDetails(ChatUser user) {
+        this.user = user;
+    }
+
+    public boolean isOwner() {
+        return user.isOwner();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getId());
+    }
+
+    // 기타 UserDetails 메서드 오버라이딩 생략
+}

--- a/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomUserDetailsService.java
+++ b/artichat/src/main/java/com/talkhasam/artichat/global/security/CustomUserDetailsService.java
@@ -5,7 +5,6 @@ import com.talkhasam.artichat.domain.chatuser.repository.ChatUserRepository;
 import com.talkhasam.artichat.global.exception.CustomException;
 import com.talkhasam.artichat.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
@@ -15,15 +14,11 @@ import org.springframework.stereotype.Service;
 public class CustomUserDetailsService implements UserDetailsService {
     private final ChatUserRepository chatUserRepository;
 
-    public UserDetails loadUserById(long userId) {
+    public CustomUserDetails loadUserById(long userId) {
         ChatUser user = chatUserRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_ACCESS_TOKEN));
-        return User.withUsername(String.valueOf(user.getId())) // principal
-                .password(user.getPassword())
-                .roles("USER")
-                .build();
+        return new CustomUserDetails(user);
     }
-
     @Override
     public UserDetails loadUserByUsername(String username) {
         return loadUserById(Long.parseLong(username));


### PR DESCRIPTION
# 구현 기능
  - CustomAuthenticationToken에 isOwner 정보 포함, CustomUserDetailsService 추가
  - isOwner에 따라 채팅 메시지 내역을 다르게 조회하기 위해